### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/pelican-plugins/assets/Readme.rst
+++ b/pelican-plugins/assets/Readme.rst
@@ -102,5 +102,5 @@ theme's top-level directory:
    )
 
 .. _Webassets: https://github.com/miracle2k/webassets
-.. _Webassets documentation: http://webassets.readthedocs.org/en/latest/builtin_filters.html
-.. _environment's register() method: http://webassets.readthedocs.org/en/latest/environment.html#registering-bundles
+.. _Webassets documentation: https://webassets.readthedocs.io/en/latest/builtin_filters.html
+.. _environment's register() method: https://webassets.readthedocs.io/en/latest/environment.html#registering-bundles

--- a/pelican-plugins/assets/assets.py
+++ b/pelican-plugins/assets/assets.py
@@ -11,7 +11,7 @@ setting. This requires the use of SITEURL in the templates::
 
     <link rel="stylesheet" href="{{ SITEURL }}/{{ ASSET_URL }}">
 
-.. _webassets: https://webassets.readthedocs.org/
+.. _webassets: https://webassets.readthedocs.io/
 
 """
 from __future__ import unicode_literals


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
